### PR TITLE
Update "Counter-Strike: Global Offensive" query

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,7 +770,7 @@ same_service(services.http.response.html_title: "Weave Scope" and services.http.
 
 ### Game Servers
 
-#### Counter-Strike Gameservers [🔎 &#x2192;](https://search.censys.io/search?resource=hosts&q=same_service%28banner%3A+%22Counter-Strike%3A+Global+Offensive+Server%22+and+service_name%3A+VALVE%29&ref=awesome-censys-queries)
+#### Counter-Strike Gameservers [🔎 &#x2192;](https://search.censys.io/search?resource=hosts&q=same_service%28banner%3A+%22Counter-Strike%22+and+service_name%3A+VALVE%29&ref=awesome-censys-queries)
 
 ```dsl
 same_service(banner: "Counter-Strike" and service_name: VALVE)

--- a/README.md
+++ b/README.md
@@ -770,10 +770,10 @@ same_service(services.http.response.html_title: "Weave Scope" and services.http.
 
 ### Game Servers
 
-#### Counter-Strike: Global Offensive [🔎 &#x2192;](https://search.censys.io/search?resource=hosts&q=same_service%28banner%3A+%22Counter-Strike%3A+Global+Offensive+Server%22+and+service_name%3A+VALVE%29&ref=awesome-censys-queries)
+#### Counter-Strike Gameservers [🔎 &#x2192;](https://search.censys.io/search?resource=hosts&q=same_service%28banner%3A+%22Counter-Strike%3A+Global+Offensive+Server%22+and+service_name%3A+VALVE%29&ref=awesome-censys-queries)
 
 ```dsl
-same_service(banner: "Counter-Strike: Global Offensive Server" and service_name: VALVE)
+same_service(banner: "Counter-Strike" and service_name: VALVE)
 ```
 
 #### FiveM [🔎 &#x2192;](https://search.censys.io/search?resource=hosts&q=services%3A+%28port%3A+30120+and+http.response.headers%3A+%28key%3A+"Location"+and+value.headers%3A+"https%3A%2F%2Fcfx.re%2Fjoin%2F*"%29%29&ref=awesome-censys-queries)


### PR DESCRIPTION
Counter-Strike: Global Offensive is deprecated, replaced by valve with Counter-Strike 2. As such, the original query returns no results. 

Querying with simply 'Counter-Strike' gives the best returns.